### PR TITLE
Fixed possible uninitialized property

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -110,7 +110,7 @@ class Client extends EventEmitter implements
         }
 
         $factory = new Factory();
-        $this->resolver = $factory->createCached($this->dnsServer, $this->loop);
+        $this->resolver = $factory->createCached($this->getDnsServer(), $this->getLoop());
 
         return $this->resolver;
     }


### PR DESCRIPTION
`$this->loop` may be not initialized yet when calling `getResolver` (`$this->dnsServer` changed for consistency).
