### PR TITLE
Capture 'end' event from read stream.

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -468,7 +468,7 @@ class Client extends EventEmitter implements
         $write->pipe($stream)->pipe($read);
         $read->on('irc.received', $this->getReadCallback($write, $connection));
         $write->on('data', $this->getWriteCallback($write, $connection));
-        $read->on('end', $this->getEndCallback($stream, $connection, $timer))
+        $read->on('end', $this->getEndCallback($stream, $connection, $timer));
         $write->on('end', $this->getEndCallback($stream, $connection, $timer));
         $error = $this->getErrorCallback($connection);
         $read->on('error', $error);

--- a/src/Client.php
+++ b/src/Client.php
@@ -468,6 +468,7 @@ class Client extends EventEmitter implements
         $write->pipe($stream)->pipe($read);
         $read->on('irc.received', $this->getReadCallback($write, $connection));
         $write->on('data', $this->getWriteCallback($write, $connection));
+        $read->on('end', $this->getEndCallback($stream, $connection, $timer))
         $write->on('end', $this->getEndCallback($stream, $connection, $timer));
         $error = $this->getErrorCallback($connection);
         $read->on('error', $error);


### PR DESCRIPTION
Currently the write stream is the only one being listened to for an 'end' event. This PR adds listening for the 'end' event from the read stream as well.

Cheers!