### PR TITLE
Improve stream handling

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -365,10 +365,9 @@ class Client extends EventEmitter implements
      */
     protected function getReadCallback(WriteStream $write, ConnectionInterface $connection)
     {
-        $client = $this;
         $logger = $this->getLogger();
-        return function($message) use ($client, $write, $connection, $logger) {
-            $client->emit('irc.received', array($message, $write, $connection, $logger));
+        return function($message) use ($write, $connection, $logger) {
+            $this->emit('irc.received', array($message, $write, $connection, $logger));
         };
     }
 
@@ -384,10 +383,9 @@ class Client extends EventEmitter implements
      */
     protected function getWriteCallback(WriteStream $write, ConnectionInterface $connection)
     {
-        $client = $this;
         $logger = $this->getLogger();
-        return function($message) use ($client, $write, $connection, $logger) {
-            $client->emit('irc.sent', array($message, $write, $connection, $logger));
+        return function($message) use ($write, $connection, $logger) {
+            $this->emit('irc.sent', array($message, $write, $connection, $logger));
         };
     }
 
@@ -401,10 +399,9 @@ class Client extends EventEmitter implements
      */
     protected function getErrorCallback(ConnectionInterface $connection)
     {
-        $client = $this;
         $logger = $this->getLogger();
-        return function($exception) use ($client, $connection, $logger) {
-            $client->emit('connect.error', array($exception, $connection, $logger));
+        return function($exception) use ($connection, $logger) {
+            $this->emit('connect.error', array($exception, $connection, $logger));
         };
     }
 
@@ -422,11 +419,10 @@ class Client extends EventEmitter implements
      */
     protected function getEndCallback(DuplexStreamInterface $stream, ConnectionInterface $connection, TimerInterface $timer)
     {
-        $client = $this;
         $logger = $this->getLogger();
-        return function() use ($client, $stream, $connection, $timer, $logger) {
-            $client->emit('connect.end', array($connection, $logger));
-            $client->cancelTimer($timer);
+        return function() use ($stream, $connection, $timer, $logger) {
+            $this->emit('connect.end', array($connection, $logger));
+            $this->cancelTimer($timer);
             $stream->close();
         };
     }
@@ -442,10 +438,9 @@ class Client extends EventEmitter implements
      */
     protected function getTickCallback(WriteStream $write, ConnectionInterface $connection)
     {
-        $client = $this;
         $logger = $this->getLogger();
-        return function() use ($client, $write, $connection, $logger) {
-            $client->emit('irc.tick', array($write, $connection, $logger));
+        return function() use ($write, $connection, $logger) {
+            $this->emit('irc.tick', array($write, $connection, $logger));
         };
     }
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -504,15 +504,21 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->client->setResolver($this->getMockResolver());
         $this->client->addConnection($connection);
 
-        Phake::verify($writeStream)->on('end', Phake::capture($callback));
-        $callback();
+        Phake::verify($writeStream)->on('end', Phake::capture($streamCloser));
+        call_user_func($streamCloser);
+        Phake::verify($stream)->end();
+
+        Phake::verify($stream)->on('end', Phake::capture($callback));
+        call_user_func($callback);
         Phake::verify($this->client)->emit('connect.end', Phake::capture($params));
         $this->assertInternalType('array', $params);
         $this->assertCount(2, $params);
         $this->assertSame($connection, $params[0]);
         $this->assertSame($logger, $params[1]);
         Phake::verify($loop)->cancelTimer($timer);
-        Phake::verify($stream)->close();
+        Phake::verify($connection)->setOption('stream', null);
+        Phake::verify($connection)->setOption('write', null);
+        Phake::verify($writeStream)->close();
     }
 
     /**
@@ -535,15 +541,21 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->client->setResolver($this->getMockResolver());
         $this->client->addConnection($connection);
 
-        Phake::verify($readStream)->on('end', Phake::capture($callback));
-        $callback();
+        Phake::verify($readStream)->on('end', Phake::capture($streamCloser));
+        call_user_func($streamCloser);
+        Phake::verify($stream)->end();
+
+        Phake::verify($stream)->on('end', Phake::capture($callback));
+        call_user_func($callback);
         Phake::verify($this->client)->emit('connect.end', Phake::capture($params));
         $this->assertInternalType('array', $params);
         $this->assertCount(2, $params);
         $this->assertSame($connection, $params[0]);
         $this->assertSame($logger, $params[1]);
         Phake::verify($loop)->cancelTimer($timer);
-        Phake::verify($stream)->close();
+        Phake::verify($connection)->setOption('stream', null);
+        Phake::verify($connection)->setOption('write', null);
+        Phake::verify($readStream)->close();
     }
 
     /**


### PR DESCRIPTION
* Closing any one of {socket stream, read stream, write stream} will result in the other two streams being closed as well.
* References to closed streams are removed from the Connection instance.
* Closing the read or write stream now calls `$stream->end()` rather than `$stream->close()` so that the send buffer is flushed first. (ref: #32)
* The closure returned by `Client::getEndCallback()` is now only called when the socket stream is closed. The `'end'` event listeners for the read and write streams now simply call `$stream->end()`.
* The prototype for `Client::getEndCallback()` has changed. It now takes the read and write stream instances as parameters, not the socket stream instance.

Unit tests are OK, but needs functional testing.