### PR TITLE
Log invalid lines

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     },
     "require": {
         "php": ">=5.4.2",
-        "phergie/phergie-irc-parser": "~1.6",
+        "phergie/phergie-irc-parser": "~2.0",
         "phergie/phergie-irc-generator": "~1.5",
         "phergie/phergie-irc-connection": "~2.0",
         "react/event-loop": "~0.4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "447132f143b9c286ac154de6420d3f42",
+    "hash": "b0680c533e0a5a1918b9d587b42a82d0",
     "packages": [
         {
             "name": "evenement/evenement",
@@ -203,23 +203,23 @@
         },
         {
             "name": "phergie/phergie-irc-parser",
-            "version": "1.6.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phergie/phergie-irc-parser.git",
-                "reference": "d233d03f6a24ff8f891de28b6d11cb8410beb315"
+                "reference": "d7dd26a724576d92e10eb7cdb7218755ed2ae108"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phergie/phergie-irc-parser/zipball/d233d03f6a24ff8f891de28b6d11cb8410beb315",
-                "reference": "d233d03f6a24ff8f891de28b6d11cb8410beb315",
+                "url": "https://api.github.com/repos/phergie/phergie-irc-parser/zipball/d7dd26a724576d92e10eb7cdb7218755ed2ae108",
+                "reference": "d7dd26a724576d92e10eb7cdb7218755ed2ae108",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=5.4.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "4.1.*"
+                "phpunit/phpunit": "~4.6"
             },
             "type": "library",
             "autoload": {
@@ -236,7 +236,7 @@
                 "irc",
                 "parser"
             ],
-            "time": "2015-03-30 17:53:50"
+            "time": "2015-05-22 00:07:09"
         },
         {
             "name": "psr/log",

--- a/src/Client.php
+++ b/src/Client.php
@@ -286,14 +286,7 @@ class Client extends EventEmitter implements
             throw new \DomainException("Invalid log level '$level'");
         }
         return function($message) use ($connection, $level, $prefix, $logger) {
-            $output = sprintf(
-                '%s!%s@%s %s%s',
-                $connection->getNickname(),
-                $connection->getUsername(),
-                $connection->getServerHostname(),
-                $prefix,
-                trim($message)
-            );
+            $output = sprintf('%s %s%s', $connection->getMask(), $prefix, trim($message));
             call_user_func(array($logger, $level), $output);
         };
     }

--- a/src/Client.php
+++ b/src/Client.php
@@ -271,6 +271,34 @@ class Client extends EventEmitter implements
     }
 
     /**
+     * Generates a closure for stream output logging.
+     *
+     * @param \Phergie\Irc\ConnectionInterface $connection
+     * @param string $level Evenement logging level to use
+     * @param string $prefix Prefix string for log lines (optional)
+     * @return callable
+     * @throws \DomainException if $level is not a valid logging level
+     */
+    protected function getOutputLogCallback(ConnectionInterface $connection, $level, $prefix = null)
+    {
+        $logger = $this->getLogger();
+        if (!method_exists($logger, $level)) {
+            throw new \DomainException("Invalid log level '$level'");
+        }
+        return function($message) use ($connection, $level, $prefix, $logger) {
+            $output = sprintf(
+                '%s!%s@%s %s%s',
+                $connection->getNickname(),
+                $connection->getUsername(),
+                $connection->getServerHostname(),
+                $prefix,
+                trim($message)
+            );
+            call_user_func(array($logger, $level), $output);
+        };
+    }
+
+    /**
      * Adds an event listener to log data emitted by a stream.
      *
      * @param \Evenement\EventEmitter $emitter
@@ -279,18 +307,8 @@ class Client extends EventEmitter implements
      */
     protected function addLogging(EventEmitter $emitter, ConnectionInterface $connection)
     {
-        $logger = $this->getLogger();
-        $callback = function($msg) use ($logger, $connection) {
-            $mask = sprintf(
-                '%s!%s@%s',
-                $connection->getNickname(),
-                $connection->getUsername(),
-                $connection->getServerHostname()
-            );
-            $logger->debug($mask . ' ' . trim($msg));
-        };
-        $emitter->on('data', $callback);
-        $emitter->on('error', $callback);
+        $emitter->on('data', $this->getOutputLogCallback($connection, 'debug'));
+        $emitter->on('error', $this->getOutputLogCallback($connection, 'notice'));
     }
 
     /**
@@ -305,6 +323,7 @@ class Client extends EventEmitter implements
     {
         $read = new ReadStream();
         $this->addLogging($read, $connection);
+        $read->on('invalid', $this->getOutputLogCallback($connection, 'notice', 'Parser unable to parse line: '));
         return $read;
     }
 
@@ -455,8 +474,7 @@ class Client extends EventEmitter implements
      * @param \Phergie\Irc\ConnectionInterface $connection Metadata for the
      *        connection over which messages are being exchanged
      * @param \React\Stream\DuplexStreamInterface $stream Stream representing the
-     *        connection
-     *        to the server
+     *        connection to the server
      * @param \Phergie\Irc\Client\React\WriteStream $write Stream used to
      *        send events to the server
      */

--- a/src/ReadStream.php
+++ b/src/ReadStream.php
@@ -72,8 +72,12 @@ class ReadStream extends WritableStream
         $this->tail = $all;
 
         foreach ($messages as $message) {
-            $this->emit('data', array($message['message']));
-            $this->emit('irc.received', array($message));
+            if (isset($message['message'])) {
+                $this->emit('data', array($message['message']));
+                $this->emit('irc.received', array($message));
+            } elseif (isset($message['invalid'])) {
+                $this->emit('invalid', array($message['invalid']));
+            }
         }
     }
 }

--- a/tests/ReadStreamTest.php
+++ b/tests/ReadStreamTest.php
@@ -115,6 +115,31 @@ class ReadStreamTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Tests write() with an invalid event.
+     */
+    public function testWriteWithInvalidEvent()
+    {
+        $parsed = array(
+            'invalid' => ":invalid:message\r\n",
+        );
+
+        $parser = $this->getMockParser();
+        Phake::when($parser)
+            ->consumeAll($parsed['invalid'])
+            ->thenReturn(array($parsed));
+
+        $read = $this->getMockReadStream();
+        $read->setParser($parser);
+        $read->write($parsed['invalid']);
+
+        Phake::verify($read)->emit('invalid', array($parsed['invalid']));
+        Phake::verify($read, Phake::never())->emit(
+            $this->logicalOr($this->equalTo('data'), $this->equalTo('irc.received')),
+            $this->anything()
+        );
+    }
+
+    /**
      * Returns a mock parser.
      *
      * @return \Phergie\Irc\ParserInterface


### PR DESCRIPTION
The read stream now sends invalid lines from parser >=2.0 to an `'invalid'` event.

Tweaked the logging setup code in the client to allow logging of different stream events at different levels.

Has not been functionally tested yet. Published for comment.