### PR TITLE
Internal processing

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -367,6 +367,7 @@ class Client extends EventEmitter implements
     {
         $logger = $this->getLogger();
         return function($message) use ($write, $connection, $logger) {
+            $this->processInput($message, $write, $connection);
             $this->emit('irc.received', array($message, $write, $connection, $logger));
         };
     }
@@ -732,5 +733,23 @@ class Client extends EventEmitter implements
     public function isTimerActive(TimerInterface $timer)
     {
         return $this->getLoop()->isTimerActive($timer);
+    }
+
+    /**
+     * There are certain incoming events that the client processes internally.
+     * These functions are essential to the client-server relationship: for example,
+     * updating the connection's stored nickname, responding to PING events, etc.
+     *
+     * Any user-level IRC functionality handled internally by the client
+     * should be implemented here.
+     *
+     * @param array $message Parser output
+     * @param \Phergie\Irc\Client\React\WriteStream $write Write stream
+     *        corresponding to the read stream on which the event occurred
+     * @param \Phergie\Irc\ConnectionInterface $connection Connection on
+     *        which the event occurred
+     */
+    protected function processInput(array $message, WriteStream $write, ConnectionInterface $connection)
+    {
     }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -758,6 +758,11 @@ class Client extends EventEmitter implements
                     $connection->setNickname($message['params']['nickname']);
                 }
                 break;
+
+            // Play client-server ping-pong
+            case 'PING':
+                $write->ircPong($message['params']['server1']);
+                break;
         }
     }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -751,5 +751,13 @@ class Client extends EventEmitter implements
      */
     protected function processInput(array $message, WriteStream $write, ConnectionInterface $connection)
     {
+        switch ($message['command']) {
+            // Update connection's internal nickname when changed
+            case 'NICK':
+                if ($connection->getNickname() === $message['nick']) {
+                    $connection->setNickname($message['params']['nickname']);
+                }
+                break;
+        }
     }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -419,6 +419,11 @@ class ClientTest extends \PHPUnit_Framework_TestCase
             $readStream,
             $writeStream
         );
+        Phake::verify($this->client)->processInput(
+            $this->message,
+            $writeStream,
+            $this->isInstanceOf('\Phergie\Irc\ConnectionInterface')
+        );
     }
 
     /**

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -17,6 +17,7 @@ use Phake;
 use Phergie\Irc\Client\React\Exception;
 use Phergie\Irc\Client\React\ReadStream;
 use Phergie\Irc\Client\React\WriteStream;
+use Phergie\Irc\ConnectionInterface;
 use React\EventLoop\LoopInterface;
 use React\SocketClient\SecureConnector;
 use React\Stream\StreamInterface;
@@ -673,6 +674,74 @@ class ClientTest extends \PHPUnit_Framework_TestCase
             Phake::verify($this->client)->emit('connect.after.all', array($connections, $writeStreams)),
             Phake::verify($loop, Phake::times(1))->run()
         );
+    }
+
+    /**
+     * Sets up and executes a test for processInput().
+     *
+     * @param array $message
+     * @param \Phergie\Irc\Client\React\WriteStream $writeStream
+     * @param \Phergie\Irc\ConnectionInterface $connection
+     */
+    protected function doInternalProcessingTest(array $message, WriteStream $writeStream, ConnectionInterface $connection)
+    {
+        $logger = $this->getMockLogger();
+        $loop = $this->getMockLoop();
+        $readStream = $this->getMockReadStream();
+        $stream = $this->getMockStream();
+        Phake::when($this->client)->getStream(Phake::anyParameters())->thenReturn($stream);
+        Phake::when($this->client)->getReadStream($connection)->thenReturn($readStream);
+        Phake::when($this->client)->getWriteStream($connection)->thenReturn($writeStream);
+
+        $this->client->setLoop($loop);
+        $this->client->setLogger($logger);
+        $this->client->setResolver($this->getMockResolver());
+        $this->client->addConnection($connection);
+
+        Phake::verify($readStream)->on('irc.received', Phake::capture($callback));
+        call_user_func($callback, $message, $writeStream, $connection);
+    }
+
+    /**
+     * Tests processInput() handling a client nickname change.
+     */
+    public function testProcessInputNickChange()
+    {
+        $connection = $this->getMockConnectionForAddConnection();
+        Phake::when($connection)->getNickname()->thenReturn('Phergie3');
+        $writeStream = $this->getMockWriteStream();
+
+        $message = array(
+            'command' => 'NICK',
+            'nick' => 'Phergie3',
+            'params' => array(
+                'nickname' => 'Phergie3_',
+            ),
+        );
+
+        $this->doInternalProcessingTest($message, $writeStream, $connection);
+
+        Phake::verify($connection)->setNickname('Phergie3_');
+    }
+
+    /**
+     * Tests processInput() handling a server ping.
+     */
+    public function testProcessInputServerPing()
+    {
+        $connection = $this->getMockConnectionForAddConnection();
+        $writeStream = $this->getMockWriteStream();
+
+        $message = array(
+            'command' => 'PING',
+            'params' => array(
+                'server1' => 'pingserver',
+            ),
+        );
+
+        $this->doInternalProcessingTest($message, $writeStream, $connection);
+
+        Phake::verify($writeStream)->ircPong('pingserver');
     }
 
     /**


### PR DESCRIPTION
ref: #40 

There are certain functions of a client that are essential to the client-server relationship, such as responding to server `PING` events.

This patch would provide a means for the client to provide such functionality as core. The method `processInput()` processes the parser output and performs whatever functionality is deemed fit. At the moment, two functions are performed, although more could be added:
* calling `Connection::setNickname()` when the server confirms that the client's nick has changed
* sending a `PONG` command when the client is pinged by the server

Very much up for discussion.