### PR TITLE
Only resolve server hostname when it isn't an IP address

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -21,6 +21,7 @@ use React\Dns\Resolver\Resolver;
 use React\EventLoop\LoopInterface;
 use React\EventLoop\Timer\TimerInterface;
 use React\Promise\Deferred;
+use React\Promise\PromiseInterface;
 use React\Stream\Stream;
 use React\Stream\DuplexStreamInterface;
 
@@ -270,8 +271,7 @@ class Client extends EventEmitter implements
         $port = $connection->getServerPort();
 
         $deferred = new Deferred();
-        $this->getResolver()
-            ->resolve($hostname)
+        $this->resolveHostname($hostname)
             ->then(
                 function($ip) use($deferred, $port) {
                     $deferred->resolve('tcp://' . $ip . ':' . $port);
@@ -282,6 +282,21 @@ class Client extends EventEmitter implements
             );
 
         return $deferred->promise();
+    }
+
+    /**
+     * Resolve an IP address from a hostname
+     *
+     * @param string $hostname
+     * @return PromiseInterface promise resolving to the hostname's IP
+     */
+    protected function resolveHostname($hostname)
+    {
+        if (false !== filter_var($hostname, FILTER_VALIDATE_IP)) {
+            return \React\Promise\resolve($hostname);
+        }
+
+        return $this->getResolver()->resolve($hostname);
     }
 
     /**

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -485,7 +485,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
      */
     public function testErrorCallbackResolverReject()
     {
-        $connection = $this->getMockConnectionForAddConnection();
+        $connection = $this->getMockConnectionForAddConnection('example.invalid');
         $logger = $this->getMockLogger();
 
         $this->client->setLogger($logger);
@@ -954,7 +954,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
      *
      * @return \Phergie\Irc\ConnectionInterface
      */
-    protected function getMockConnectionForAddConnection()
+    protected function getMockConnectionForAddConnection($hostname = '0.0.0.0')
     {
         $connection = $this->getMockConnection();
         Phake::when($connection)->getPassword()->thenReturn('password');
@@ -963,7 +963,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         Phake::when($connection)->getServername()->thenReturn('servername');
         Phake::when($connection)->getRealname()->thenReturn('realname');
         Phake::when($connection)->getNickname()->thenReturn('nickname');
-        Phake::when($connection)->getServerHostname()->thenReturn('0.0.0.0');
+        Phake::when($connection)->getServerHostname()->thenReturn($hostname);
         Phake::when($connection)->getServerPort()->thenReturn($this->port);
         Phake::when($connection)->getMask()->thenReturn('nickname!username@0.0.0.0');
         return $connection;


### PR DESCRIPTION
# Don't merge yet

Currently the client doesn't  check whenever the inputted hostname is an IP address or FQDN. This patch will resolve that issue.
