### PR TITLE
Test with pecl event

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,14 @@ matrix:
     - php: 5.6
       env: PECLEVENT=1
     - php: 7
-      env: PECLEVENT=1 PECLINI=1
+      env: PECLEVENT=1
+    - php: 7.1
+      env: PECLEVENT=1
   allow_failures:
     - php: hhvm
 
 before_script:
   - if [[ $PECLEVENT = 1 ]]; then yes \"\" | pecl install event; fi
-  - if [[ $PECLINI = 1 ]]; then echo 'extension = event.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
   - composer self-update
   - composer install --dev
   - mkdir -p build/logs

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,17 @@ php:
   - hhvm
 
 matrix:
+  include:
+    - php: 5.6
+      env: PECLEVENT=1
+    - php: 7
+      env: PECLEVENT=1 PECLINI=1
   allow_failures:
     - php: hhvm
 
 before_script:
+  - if [[ $PECLEVENT = 1 ]]; then yes \"\" | pecl install event; fi
+  - if [[ $PECLINI = 1 ]]; then echo 'extension = event.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
   - composer self-update
   - composer install --dev
   - mkdir -p build/logs

--- a/composer.lock
+++ b/composer.lock
@@ -364,16 +364,16 @@
         },
         {
             "name": "react/event-loop",
-            "version": "v0.4.1",
+            "version": "v0.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/event-loop.git",
-                "reference": "18c5297087ca01de85518e2b55078f444144aa1b"
+                "reference": "164799f73175e1c80bba92a220ea35df6ca371dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/event-loop/zipball/18c5297087ca01de85518e2b55078f444144aa1b",
-                "reference": "18c5297087ca01de85518e2b55078f444144aa1b",
+                "url": "https://api.github.com/repos/reactphp/event-loop/zipball/164799f73175e1c80bba92a220ea35df6ca371dd",
+                "reference": "164799f73175e1c80bba92a220ea35df6ca371dd",
                 "shasum": ""
             },
             "require": {
@@ -387,12 +387,12 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.4-dev"
+                    "dev-master": "0.5-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "React\\EventLoop\\": ""
+                    "React\\EventLoop\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -401,9 +401,10 @@
             ],
             "description": "Event loop abstraction layer that libraries can use for evented I/O.",
             "keywords": [
+                "asynchronous",
                 "event-loop"
             ],
-            "time": "2014-02-26 17:36:58"
+            "time": "2016-03-08 02:09:32"
         },
         {
             "name": "react/promise",
@@ -787,6 +788,7 @@
                 "rest",
                 "web service"
             ],
+            "abandoned": "guzzlehttp/guzzle",
             "time": "2015-03-18 18:23:50"
         },
         {


### PR DESCRIPTION
Using the PECL event extension results in a fatal error. There is a fix for this here: https://github.com/reactphp/event-loop/releases/tag/v0.4.2 I'll be happy to add the commit to update react/event-loop, but I just wanted you folks to see why (in the tests) :)

For more info see this pull request: https://github.com/reactphp/event-loop/pull/45