### PR TITLE
Use Connection::getData where appropriate

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -667,7 +667,7 @@ class Client extends EventEmitter implements
             ->then(
                 function(DuplexStreamInterface $stream) use ($connection) {
                     $this->initializeStream($stream, $connection);
-                    $this->emit('connect.after.each', array($connection, $connection->getOption('write')));
+                    $this->emit('connect.after.each', array($connection, $connection->getData('write')));
                 }
             );
     }
@@ -709,7 +709,7 @@ class Client extends EventEmitter implements
             $this->emitConnectionError($e, $connection);
         }
 
-        $this->emit('connect.after.each', array($connection, $connection->getOption('write')));
+        $this->emit('connect.after.each', array($connection, $connection->getData('write')));
     }
 
     /**
@@ -759,7 +759,7 @@ class Client extends EventEmitter implements
 
         $writes = array_map(
             function($connection) {
-                return $connection->getOption('write');
+                return $connection->getData('write');
             },
             $connections
         );

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -239,7 +239,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         Phake::when($connection)->getPassword()->thenReturn(null);
         $writeStream = $this->getMockWriteStream();
         Phake::when($this->client)->getWriteStream($connection)->thenReturn($writeStream);
-        Phake::when($connection)->getOption('write')->thenReturn($writeStream);
+        Phake::when($connection)->getData('write')->thenReturn($writeStream);
 
         $this->client->setLogger($this->getMockLogger());
         $this->client->setResolver($this->getMockResolver());
@@ -267,7 +267,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $connection = $this->getMockConnectionForAddConnection();
         $writeStream = $this->getMockWriteStream();
         Phake::when($this->client)->getWriteStream($connection)->thenReturn($writeStream);
-        Phake::when($connection)->getOption('write')->thenReturn($writeStream);
+        Phake::when($connection)->getData('write')->thenReturn($writeStream);
 
         $this->client->setLogger($this->getMockLogger());
         $this->client->setResolver($this->getMockResolver());
@@ -616,8 +616,8 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $writeStreams = array($writeStream1, $writeStream2);
         Phake::when($this->client)->getWriteStream($connection1)->thenReturn($writeStream1);
         Phake::when($this->client)->getWriteStream($connection2)->thenReturn($writeStream2);
-        Phake::when($connection1)->getOption('write')->thenReturn($writeStream1);
-        Phake::when($connection2)->getOption('write')->thenReturn($writeStream2);
+        Phake::when($connection1)->getData('write')->thenReturn($writeStream1);
+        Phake::when($connection2)->getData('write')->thenReturn($writeStream2);
 
         $this->client->setLogger($this->getMockLogger());
         $this->client->setResolver($this->getMockResolver('null'));
@@ -642,7 +642,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $connections = array($connection);
         $writeStream = $this->getMockWriteStream();
         $writeStreams = array($writeStream);
-        Phake::when($connection)->getOption('write')->thenReturn($writeStream);
+        Phake::when($connection)->getData('write')->thenReturn($writeStream);
         Phake::when($this->client)->getWriteStream($connection)->thenReturn($writeStream);
         Phake::when($this->client)->getLoop()->thenReturn($loop);
 
@@ -668,7 +668,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $connections = array($connection);
         $writeStream = $this->getMockWriteStream();
         $writeStreams = array($writeStream);
-        Phake::when($connection)->getOption('write')->thenReturn($writeStream);
+        Phake::when($connection)->getData('write')->thenReturn($writeStream);
         Phake::when($this->client)->getWriteStream($connection)->thenReturn($writeStream);
         Phake::when($this->client)->getLoop()->thenReturn($loop);
 
@@ -695,7 +695,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $connections = array($connection);
         $writeStream = $this->getMockWriteStream();
         $writeStreams = array($writeStream);
-        Phake::when($connection)->getOption('write')->thenReturn($writeStream);
+        Phake::when($connection)->getData('write')->thenReturn($writeStream);
         Phake::when($connection)->getOption('transport')->thenReturn('ssl');
         Phake::when($this->client)->getWriteStream($connection)->thenReturn($writeStream);
         Phake::when($this->client)->getLoop()->thenReturn($loop);


### PR DESCRIPTION
As specified by Phergie\Irc\ConnectionInterface::getData should be used
for runtime data.

Closes #57 