### PR TITLE
Alias timer interface for event-loop 0.4 and 0.5 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
     "autoload": {
         "psr-4": {
             "Phergie\\Irc\\Client\\React\\": "src"
-        }
+        },
+        "files": ["src/timer_class_alias.php"]
     },
     "autoload-dev": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "phergie/phergie-irc-parser": "~2.0",
         "phergie/phergie-irc-generator": "~1.5",
         "phergie/phergie-irc-connection": "~2.0",
-        "react/event-loop": "^1.0 || ^0.5 || ^0.4.0",
+        "react/event-loop": "^1.0 || ^0.5",
         "react/stream": "^1.0 || ^0.7 || ^0.6 || ^0.5 || ^0.4",
         "react/socket": "^1.0 || ^0.8 || ^0.7",
         "react/dns": "~0.4.0",
@@ -31,8 +31,7 @@
     "autoload": {
         "psr-4": {
             "Phergie\\Irc\\Client\\React\\": "src"
-        },
-        "files": ["src/timer_class_alias.php"]
+        }
     },
     "autoload-dev": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "c00f627875c74e37142749a93e3723f2",
+    "content-hash": "cdd6f771342dfc2ca49f7e14a0a147eb",
     "packages": [
         {
             "name": "evenement/evenement",
@@ -365,28 +365,27 @@
         },
         {
             "name": "react/event-loop",
-            "version": "v0.4.3",
+            "version": "v0.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/event-loop.git",
-                "reference": "8bde03488ee897dc6bb3d91e4e17c353f9c5252f"
+                "reference": "e94985d93c689c554265b01014f8c3064921ca27"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/event-loop/zipball/8bde03488ee897dc6bb3d91e4e17c353f9c5252f",
-                "reference": "8bde03488ee897dc6bb3d91e4e17c353f9c5252f",
+                "url": "https://api.github.com/repos/reactphp/event-loop/zipball/e94985d93c689c554265b01014f8c3064921ca27",
+                "reference": "e94985d93c689c554265b01014f8c3064921ca27",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4.0"
+                "php": ">=5.3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.8"
+                "phpunit/phpunit": "~4.8.35 || ^5.7 || ^6.4"
             },
             "suggest": {
-                "ext-event": "~1.0",
-                "ext-libev": "*",
-                "ext-libevent": ">=0.1.0"
+                "ext-event": "~1.0 for ExtEventLoop",
+                "ext-pcntl": "For signal handling support when using the StreamSelectLoop"
             },
             "type": "library",
             "autoload": {
@@ -398,12 +397,12 @@
             "license": [
                 "MIT"
             ],
-            "description": "Event loop abstraction layer that libraries can use for evented I/O.",
+            "description": "ReactPHP's core reactor event loop that libraries can use for evented I/O.",
             "keywords": [
                 "asynchronous",
                 "event-loop"
             ],
-            "time": "2017-04-27T10:56:23+00:00"
+            "time": "2018-04-24T11:23:06+00:00"
         },
         {
             "name": "react/promise",
@@ -1558,6 +1557,7 @@
                 "github",
                 "test"
             ],
+            "abandoned": "php-coveralls/php-coveralls",
             "time": "2013-05-04T08:07:33+00:00"
         },
         {

--- a/src/Client.php
+++ b/src/Client.php
@@ -823,20 +823,6 @@ class Client extends EventEmitter implements
     }
 
     /**
-     * Checks if a timer created using addTimer() or addPeriodicTimer() is
-     * active. Proxies to the isTimerActive() implementation of the event loop
-     * implementation returned by getLoop().
-     *
-     * @param \React\EventLoop\Timer\TimerInterface $timer Timer returned by
-     *        addTimer() or addPeriodicTimer()
-     * @return boolean TRUE if the specified timer is active, FALSE otherwise
-     */
-    public function isTimerActive(TimerInterface $timer)
-    {
-        return $this->getLoop()->isTimerActive($timer);
-    }
-
-    /**
      * There are certain incoming events that the client processes internally.
      * These functions are essential to the client-server relationship: for example,
      * updating the connection's stored nickname, responding to PING events, etc.

--- a/src/Client.php
+++ b/src/Client.php
@@ -19,7 +19,7 @@ use Phergie\Irc\ConnectionInterface;
 use React\Dns\Resolver\Factory;
 use React\Dns\Resolver\Resolver;
 use React\EventLoop\LoopInterface;
-use React\EventLoop\Timer\TimerInterface;
+use React\EventLoop\TimerInterface;
 use React\Promise\Deferred;
 use React\Promise\PromiseInterface;
 use React\Stream\DuplexResourceStream;

--- a/src/timer_class_alias.php
+++ b/src/timer_class_alias.php
@@ -1,5 +1,0 @@
-<?php
-
-if (!interface_exists('React\EventLoop\TimerInterface') && interface_exists('React\EventLoop\Timer\TimerInterface')) {
-    class_alias('React\EventLoop\Timer\TimerInterface', 'React\EventLoop\TimerInterface');
-}

--- a/src/timer_class_alias.php
+++ b/src/timer_class_alias.php
@@ -1,0 +1,5 @@
+<?php
+
+if (!interface_exists('React\EventLoop\TimerInterface') && interface_exists('React\EventLoop\Timer\TimerInterface')) {
+    class_alias('React\EventLoop\Timer\TimerInterface', 'React\EventLoop\TimerInterface');
+}

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -822,20 +822,6 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Tests isTimerActive().
-     */
-    public function testIsTimerActive()
-    {
-        $timer = $this->getMockTimer();
-        $loop = $this->getMockLoop();
-        Phake::when($this->client)->getLoop()->thenReturn($loop);
-
-        $this->client->isTimerActive($timer);
-
-        Phake::verify($loop)->isTimerActive($timer);
-    }
-
-    /**
      * Returns a mock logger.
      *
      * @return \Psr\Log\LoggerInterface
@@ -848,11 +834,11 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     /**
      * Returns a mock timer.
      *
-     * @return \React\EventLoop\Timer\TimerInterface
+     * @return \React\EventLoop\TimerInterface
      */
     protected function getMockTimer()
     {
-        return Phake::mock('\React\EventLoop\Timer\TimerInterface');
+        return Phake::mock('\React\EventLoop\TimerInterface');
     }
 
     /**


### PR DESCRIPTION
In `react/event-loop` 0.5 we moved the `TimerInterface` in https://github.com/reactphp/event-loop/pull/138. This PR adds a compatibility file to make sure this package keeps working with `event-loop` `0.4` and `0.5`.